### PR TITLE
Configure Travis to deploy successful master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: node_js
 node_js:
   - 6
+script: npm run ci
+deploy:
+  provider: surge
+  project: ./app/
+  domain: shimu-hd.surge.sh
+  skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:watch": "npm run test -- -w",
     "build": "rollup -c",
     "build:watch": "npm run build -- -w",
+    "ci": "npm run test && npm run build",
     "deploy": "surge -p ./app -d shimu-hd.surge.sh"
   },
   "repository": {


### PR DESCRIPTION
Add a CI script that determines the success of a build, in addition to generating the game "binary". Configure Travis to upload the built code for successful `master` builds.