### PR TITLE
Increased initial heat of PlasmaBullet

### DIFF
--- a/src/entities/Bullet.js
+++ b/src/entities/Bullet.js
@@ -60,7 +60,7 @@ export class LineBullet extends Bullet {
 export class PlasmaBullet extends Bullet {
   constructor(position, direction, owner) {
     super(position, direction, owner)
-    this.heat = 90;
+    this.heat = 900;
     this.color = 'orange';
     this.size = new Size(4, 4);
     this.speed /= 5;


### PR DESCRIPTION
The final change to have heat decrease with delta was a last minute change that was not play-tested properly.
The life-time of a bullet is far too short for practical use.
This increase the heat by 10 to compensate for the 16 times extra loss.