### PR TITLE
fixed bug in enemy spawning 

### DIFF
--- a/src/Logic.js
+++ b/src/Logic.js
@@ -19,9 +19,12 @@ export class Logic {
   update(game, delta) {
     this.timeSinceSpawn += delta;
 
-    if (this.timeSinceSpawn >= 15000 || game.entities.length < 10) {
+    if (this.timeSinceSpawn >= 15000 || game.entities.filter(e => e instanceof Enemy).length < 10) {
       spawnEnemies(game, this.level++);
       this.timeSinceSpawn -= 15000;
+      if (this.timeSinceSpawn < 0) {
+        this.timeSinceSpawn = 0;
+      }
     }
   }
 }


### PR DESCRIPTION
It caused increasing time before automatic respawns if the player is not terrible and kills off enemies faster than 15 seconds.

This fix makes sure the time since  last spawn counter never go below 0 (except in the case of a overflow).