### PR TITLE
Limited the amount of levels to spawn at once

### DIFF
--- a/src/Logic.js
+++ b/src/Logic.js
@@ -21,11 +21,13 @@ export class Logic {
   }
 
   update(game, delta) {
-    this.timeSinceSpawn += delta;
+    const timeToSpawn = 15000
+    
+    this.timeSinceSpawn += Math.min(delta, timeToSpawn);
 
-    if (this.timeSinceSpawn >= 15000 || game.entities.filter(e => e instanceof Enemy).length < 10) {
+    if (this.timeSinceSpawn >= timeToSpawn || game.entities.filter(e => e instanceof Enemy).length < 10) {
       spawnEnemies(game, this.level++);
-      this.timeSinceSpawn -= 15000;
+      this.timeSinceSpawn -= timeToSpawn;
       if (this.timeSinceSpawn < 0) {
         this.timeSinceSpawn = 0;
       }


### PR DESCRIPTION
Logic.update used to not contain a upper limit on timeSinceSpawn causing a game that been left in the background for a while to completely swamp the computers resources with several hundred of level spawns, since the first call would put timeSinceSpawn way higher than intended and for each frame afterwards spawning a new set of enemies since the value is still much higher than the respawn timelimit.