### PR TITLE
Moved spawning out of Logic.

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -1,5 +1,5 @@
 import {Keyboard} from './controls.js';
-import {Entity, Shimu} from './entities/all.js';
+import {Entity} from './entities/all.js';
 import {Size, Vec2} from './core.js';
 
 export class Game {
@@ -32,9 +32,6 @@ export class Game {
   }
 
   initialize() {
-    this.player = new Shimu(new Vec2(50, 50), this.controls);
-    this.entities.push(this.player);
-
     this.logic.initialize(this);
   }
 

--- a/src/Game_test.js
+++ b/src/Game_test.js
@@ -44,9 +44,6 @@ describe('Game', () => {
     const game = new Game(fakeContext, logic, null, null);
     game.initialize();
 
-    // Assume the player character is the only entity.
-    assert.deepEqual(game.entities, [game.player]);
-
     // `logic.initialize` should be called with the game instance.
     assert.deepEqual(logic.initialize.args, [game]);
   });

--- a/src/Logic.js
+++ b/src/Logic.js
@@ -4,16 +4,17 @@ import {CollisionRules} from './collision/CollisionRules.js';
 import {Modern} from './collision/modern.js';
 
 export class Logic {
-  constructor(ruleset) {
+  constructor(ruleset, spawner) {
     this.running = true;
     this.level = 0;
     this.timeSinceSpawn = 0;
     this.collision = new CollisionRules();
     ruleset.initialize(this.collision);
+    this.spawner = spawner;
   }
 
   initialize(game) {
-    spawnEnemies(game, this.level++);
+    this.spawner.initialize(game, this.level++);
   }
 
   continue() {
@@ -24,7 +25,7 @@ export class Logic {
     this.timeSinceSpawn += delta;
 
     if (this.timeSinceSpawn >= 15000 || game.entities.filter(e => e instanceof Enemy).length < 10) {
-      spawnEnemies(game, this.level++);
+      this.spawner.spawn(game, this.level++);
       this.timeSinceSpawn -= 15000;
       if (this.timeSinceSpawn < 0) {
         this.timeSinceSpawn = 0;
@@ -58,17 +59,4 @@ export class Logic {
   }
 }
 
-function spawnEnemies(game, level) {
-  for (let i = 0; i < 30; i++) {
-    game.entities.push(Enemy.standard(bogoSpawn(game.getSize(), game.player), 0.05 + 0.002*level))
-  }
-}
 
-function bogoSpawn(size, player) {
-  let position = new Vec2(0, 0);
-  do {
-    position.x = Math.random()*size.width;
-    position.y = Math.random()*size.height;
-  } while (Vec2.sub(position, player.position).length() < 100)
-  return position;
-}

--- a/src/Logic_test.js
+++ b/src/Logic_test.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import {Context, Controls} from './testing/fakes.js';
+import {createArgSaver} from './testing/mocks.js';
 import {Game} from './Game.js';
 import {Logic} from './Logic.js';
 import {Size} from './core.js';
@@ -12,7 +13,10 @@ describe('Logic', () => {
   }
 
   it('initializes a Game with initial enemies', () => {
-    const logic = new Logic(ruleset);
+    const spawner = {
+      initialize: createArgSaver()
+    }
+    const logic = new Logic(ruleset, spawner);
     assert.equal(logic.level, 0);
 
     const game = new Game(context, logic, null, null);
@@ -20,23 +24,31 @@ describe('Logic', () => {
     game.initialize();
     assert.equal(logic.level, 1);
 
-    assert(game.entities.filter(e => e instanceof Enemy).length > 0,
+    assert.deepEqual(spawner.initialize.args, [game, 0],
       'game should be initialized with at least one enemy');
   });
 
   it('updates the Game state with more enemies if required', () => {
-    const logic = new Logic(ruleset);
+    const spawner = {
+      initialize: () => {},
+      spawn: createArgSaver()
+    }
+    const logic = new Logic(ruleset, spawner);
     const controls = new Controls();
 
     const game = new Game(context, logic, controls, null);
     game.initialize();
 
-    const entities = game.entities.length;
+    for (var i = 0; i < 20; i++) {
+      game.entities.push(new Enemy());
+    }
+
 
     game.update(5000);
-    assert.equal(game.entities.length, entities);
+    assert.equal(spawner.spawn.times, 0);
+    game.update(2000);
 
-    game.update(10000);
-    assert.equal(game.entities.length, entities + 30);
+    game.update(8000);
+    assert.equal(spawner.spawn.times, 1);
   });
 });

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import {Game} from './Game.js';
 import {Modern} from './collision/modern.js';
+import {LegacySpawner} from './spawning/LegacySpawner.js';
 import {Logic} from './Logic.js';
 import * as controls from './controls.js';
 import {createAnimationTicker} from './tickers.js';
@@ -13,7 +14,7 @@ export default {
   start(canvas) {
     const Controls = getControls();
 
-    const logic = new Logic(Modern);
+    const logic = new Logic(Modern, new LegacySpawner());
     const ctrl = new Controls(canvas);
     const ticker = createAnimationTicker();
     new Game(canvas.getContext('2d'), logic, ctrl, ticker).start();

--- a/src/spawning/LegacySpawner.js
+++ b/src/spawning/LegacySpawner.js
@@ -1,0 +1,29 @@
+import {Vec2} from '../core.js';
+import {Shimu, Enemy} from '../entities/all.js';
+
+export class LegacySpawner {
+  initialize(game, level) {
+    game.player = new Shimu(new Vec2(50, 50), game.controls);
+    game.entities.push(game.player);
+
+    this.spawn(game, level);
+  };
+
+  spawn(game, level) {
+    for (let i = 0; i < 30; i++) {
+      game.entities.push(
+        Enemy.standard(
+          bogoSpawn(game.getSize(), game.player), 
+          0.05 + 0.002*level))
+    }
+  };
+}
+
+function bogoSpawn(size, player) {
+  let position = new Vec2(0, 0);
+  do {
+    position.x = Math.random()*size.width;
+    position.y = Math.random()*size.height;
+  } while (Vec2.sub(position, player.position).length() < 100)
+  return position;
+}

--- a/src/spawning/LegacySpawner_test.js
+++ b/src/spawning/LegacySpawner_test.js
@@ -1,0 +1,31 @@
+import assert from 'assert';
+import {createArgSaver} from '../testing/mocks.js';
+import {Context} from '../testing/fakes.js';
+import {Vec2, Size} from '../core.js';
+import {Game} from '../Game.js';
+import {Enemy} from '../entities/all.js';
+import {LegacySpawner} from './LegacySpawner.js';
+
+describe('LegacySpawner', () => {
+	const context = new Context(new Size(300, 100));
+	it('spawns a player and a set of enemies during initialization', () => {
+		const spawner = new LegacySpawner();
+		const game = new Game(context, null, null, null);
+
+		spawner.initialize(game, 0);
+
+		assert.notStrictEqual(game.player, null, 'Player has been spawned');
+		assert.equal(game.entities.filter(e => e instanceof Enemy).length, 30);
+	});
+
+	it('spawns more enemies', () => {
+		const spawner = new LegacySpawner();
+		const game = new Game(context, null, null, null);
+		game.player = {
+			position: new Vec2(4, 10)
+		}
+		spawner.spawn(game, 3);
+
+		assert.equal(game.entities.filter(e => e instanceof Enemy).length, 30);
+	});
+});


### PR DESCRIPTION
I never really liked that spawning was a thing for Logic.
The idea that Bogospawn was at the center of out game logic just felt wrong.

Then today I was thinking about fun stuff we can do in this modern version of the game.
And how we could not do it in the same functions that also serve the Legacy.

So this is the broken out spawning of all entities. Even the player.
This allows us to do stuff like respawning, spawning different enemies as different levels, spawn enemies according to different rules.

This can also tie into level packs where each levels enemies is defined in some dataformat that is loaded by the Spawner. Challenge Packs, Deterministic Spawning, Speedruns.. It all lie before our feets, ready for implementing. 